### PR TITLE
Fixing the loading and logging of History class

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -5,10 +5,59 @@
       {
         "programmeName": "Starter",
         "dayList": []
+      },
+      {
+        "programmeName": "Starter",
+        "dayList": [
+          {
+            "name": "ONE",
+            "exercises": [
+              {
+                "sets": 3,
+                "reps": 12,
+                "weight": 30,
+                "name": "Bench_Press"
+              },
+              {
+                "sets": 3,
+                "reps": 12,
+                "weight": 50,
+                "name": "Squat"
+              }
+            ]
+          },
+          {
+            "name": "TWO",
+            "exercises": [
+              {
+                "sets": 3,
+                "reps": 12,
+                "weight": 10,
+                "name": "Bicep_Curl"
+              }
+            ]
+          }
+        ]
       }
     ]
   },
   "history": {
-    "history": {}
+    "12/12/2024": {
+      "name": "ONE",
+      "exercises": [
+        {
+          "sets": 3,
+          "reps": 12,
+          "weight": 30,
+          "name": "Bench_Press"
+        },
+        {
+          "sets": 3,
+          "reps": 12,
+          "weight": 50,
+          "name": "Squat"
+        }
+      ]
+    }
   }
 }

--- a/src/main/java/command/LogCommand.java
+++ b/src/main/java/command/LogCommand.java
@@ -4,7 +4,7 @@ import programme.ProgrammeList;
 import programme.Day;
 import core.History;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 
 public class LogCommand extends Command {
@@ -12,9 +12,9 @@ public class LogCommand extends Command {
 
     private final int progIndex;
     private final int dayIndex;
-    private final LocalDateTime date;
+    private final LocalDate date;
 
-    public LogCommand(int progIndex, int dayIndex, LocalDateTime date){
+    public LogCommand(int progIndex, int dayIndex, LocalDate date){
         this.progIndex = progIndex;
         this.dayIndex = dayIndex;
         this.date = date;

--- a/src/main/java/core/DateSerializer.java
+++ b/src/main/java/core/DateSerializer.java
@@ -20,7 +20,6 @@ public class DateSerializer implements JsonSerializer<LocalDate>, JsonDeserializ
 
     @Override
     public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-        System.out.println("enter deseralize");
         return LocalDate.parse(json.getAsString(), formatter);
     }
 }

--- a/src/main/java/core/DateSerializer.java
+++ b/src/main/java/core/DateSerializer.java
@@ -6,20 +6,21 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonDeserializationContext;
 import java.lang.reflect.Type;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-public class DateSerializer implements JsonSerializer<LocalDateTime>, JsonDeserializer<LocalDateTime> {
+public class DateSerializer implements JsonSerializer<LocalDate>, JsonDeserializer<LocalDate> {
 
-    private static final DateTimeFormatter formatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
     @Override
-    public JsonElement serialize(LocalDateTime src, Type typeOfSrc, JsonSerializationContext context) {
+    public JsonElement serialize(LocalDate src, Type typeOfSrc, JsonSerializationContext context) {
         return new JsonPrimitive(src.format(formatter));  
     }
 
     @Override
-    public LocalDateTime deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
-        return LocalDateTime.parse(json.getAsString(), formatter); 
+    public LocalDate deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) {
+        System.out.println("enter deseralize");
+        return LocalDate.parse(json.getAsString(), formatter);
     }
 }

--- a/src/main/java/core/History.java
+++ b/src/main/java/core/History.java
@@ -52,9 +52,7 @@ public class History {
         // Iterate through the JSON keys (dates) and deserialize them as LocalDate and Day objects
         for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
             LocalDate date = LocalDate.parse(entry.getKey(), formatter);  // Convert key to LocalDate
-            System.out.println(date);
             Day day = gson.fromJson(entry.getValue(), Day.class);  // Deserialize the Day object
-            System.out.println(day);
             history.history.put(date, day);  // Add to the HashMap
         }
 

--- a/src/main/java/core/History.java
+++ b/src/main/java/core/History.java
@@ -2,12 +2,16 @@ package core;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonDeserializer;
 import programme.Day;
 
+import javax.xml.crypto.Data;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.Map;
 
 public class History {
 
@@ -27,9 +31,16 @@ public class History {
     public JsonObject toJson() {
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(LocalDate.class, new DateSerializer())
+                .setPrettyPrinting()
                 .create();
+        JsonObject historyJson = new JsonObject();
+        for (LocalDate date : history.keySet()) {
+            Day day = history.get(date);
+            // Add each entry in the HashMap to the JsonObject, using the date as the key
+            historyJson.add(date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")), gson.toJsonTree(day));
+        }
 
-        return gson.toJsonTree(this).getAsJsonObject();
+        return historyJson;
     }
 
     // Creates a History object from a JSON string
@@ -37,7 +48,19 @@ public class History {
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(LocalDate.class, new DateSerializer())
                 .create();
-        return gson.fromJson(jsonObject, History.class);
+        History history = new History();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+
+        // Iterate through the JSON keys (dates) and deserialize them as LocalDate and Day objects
+        for (Map.Entry<String, JsonElement> entry : jsonObject.entrySet()) {
+            LocalDate date = LocalDate.parse(entry.getKey(), formatter);  // Convert key to LocalDate
+            System.out.println(date);
+            Day day = gson.fromJson(entry.getValue(), Day.class);  // Deserialize the Day object
+            System.out.println(day);
+            history.history.put(date, day);  // Add to the HashMap
+        }
+
+        return history;
     }
 
     // Standard toString method for History class that represents the history

--- a/src/main/java/core/History.java
+++ b/src/main/java/core/History.java
@@ -4,10 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonDeserializer;
 import programme.Day;
 
-import javax.xml.crypto.Data;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;

--- a/src/main/java/core/History.java
+++ b/src/main/java/core/History.java
@@ -5,13 +5,13 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import programme.Day;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 
 public class History {
 
-    private final HashMap<LocalDateTime, Day> history;  // HashMap to store Day with its respective date
+    private final HashMap<LocalDate, Day> history;  // HashMap to store Day with its respective date
 
     // Constructor
     public History() {
@@ -19,14 +19,14 @@ public class History {
     }
 
     // Logs a completed day into the history with a given date
-    public void logDay(Day day, LocalDateTime date) {
+    public void logDay(Day day, LocalDate date) {
         history.put(date, day);  // Use HashMap to store or update the day with its date
     }
 
     // Converts the History object to a JSON string
     public JsonObject toJson() {
         Gson gson = new GsonBuilder()
-                .registerTypeAdapter(LocalDateTime.class, new DateSerializer())
+                .registerTypeAdapter(LocalDate.class, new DateSerializer())
                 .create();
 
         return gson.toJsonTree(this).getAsJsonObject();
@@ -35,7 +35,7 @@ public class History {
     // Creates a History object from a JSON string
     public static History fromJson(JsonObject jsonObject) {
         Gson gson = new GsonBuilder()
-                .registerTypeAdapter(LocalDateTime.class, new DateSerializer())
+                .registerTypeAdapter(LocalDate.class, new DateSerializer())
                 .create();
         return gson.fromJson(jsonObject, History.class);
     }
@@ -52,7 +52,7 @@ public class History {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 
         // Iterate over the history HashMap
-        for (LocalDateTime date : history.keySet()) {
+        for (LocalDate date : history.keySet()) {
             Day day = history.get(date);
             historyString.append(String.format("Day: %s%nCompleted On:%s%n%n",day,date.format(formatter)));
         }

--- a/src/main/java/parser/Parser.java
+++ b/src/main/java/parser/Parser.java
@@ -7,7 +7,7 @@ import command.LogCommand;
 import command.InvalidCommand;
 
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 import static parser.ParserUtils.parseIndex;
@@ -41,7 +41,7 @@ public class Parser {
     private Command prepareLogCommand(String argumentString){
         int progIndex = -1;
         int dayIndex = -1;
-        LocalDateTime date = LocalDateTime.now();
+        LocalDate date = LocalDate.now();
 
         String[] arguments = argumentString.split(" (?=/[tdp])");
 
@@ -68,8 +68,8 @@ public class Parser {
     }
 
 
-    private LocalDateTime parseDate(String dateString) {
+    private LocalDate parseDate(String dateString) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
-        return LocalDateTime.parse(dateString, formatter);
+        return LocalDate.parse(dateString, formatter);
     }
 }


### PR DESCRIPTION
There was a bug becasue of the following reasons 
- using LocalDateTime instead of LocalDate
- Some parts were using yyyy-MM-dd and some were using dd/MM/yyyy
- There was an additional wrapper for history when it loads so like within the data. History had another History inside, so the load was reading Null. The additonal wrapper was caused by hisotry being a hashmap. 
To solve that, I toJson each day instead of the hisotyr itself. This can easily be changed to log (which is a weapper for day, meals, water). 


Now History loads and logs properly